### PR TITLE
Fix `make lint` fail on master

### DIFF
--- a/h_pyramid_sentry/__init__.py
+++ b/h_pyramid_sentry/__init__.py
@@ -39,6 +39,7 @@ def includeme(config):
     ]
 
     if asbool(config.registry.settings.get("h_pyramid_sentry.retry_support")):
+        # pylint:disable=import-outside-toplevel
         from h_pyramid_sentry.filters.pyramid import is_retryable_error
 
         filters.append(is_retryable_error)

--- a/h_pyramid_sentry/__init__.py
+++ b/h_pyramid_sentry/__init__.py
@@ -40,6 +40,7 @@ def includeme(config):
 
     if asbool(config.registry.settings.get("h_pyramid_sentry.retry_support")):
         # pylint:disable=import-outside-toplevel
+        # This is here to lazy load only when required
         from h_pyramid_sentry.filters.pyramid import is_retryable_error
 
         filters.append(is_retryable_error)


### PR DESCRIPTION
New pylint release today added a new warning that broke `make lint`:

http://pylint.pycqa.org/en/latest/whatsnew/changelog.html#what-s-new-in-pylint-2-4-3

This is a general problem we have across our projects: we need to move tools like pylint into a `requirements-lint.txt` file and pin them to an exact version, instead of just listing them un-pinned in `tox.ini` or elsewhere.. That way the exact same version of the tool will always be used in everyone's dev env and on CI, so it will either be working everywhere or failing everywhere. And when a new version of pylint comes out Dependabot will send us a PR to upgrade it in `requirements-lint.txt` and if the new version breaks anything the tests will fail on that PR.

Same goes for all tooling (linters, formatters, ...) and tests (pylint, ...) dependencies.

For now just doing this one-off fix.