### PR TITLE
Removing celery as a direct install dependency and adding option

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,10 @@ The extension will listen to the following Pyramid deployment settings:
 |------------------------|---------------|
 | `h_pyramid_sentry.init` | A dict of any [options understood by `sentry_sdk.init()`](https://docs.sentry.io/error-reporting/configuration/?platform=javascript#common-options) |
 | `h_pyramid_sentry.filters` | A list of functions to apply as filters |
-| `h_pyramid_sentry.retry_support` | Enable retry detection and filtering |
+| `h_pyramid_sentry.retry_support` *| Enable retry detection and filtering|
+| `h_pyramid_sentry.celery_support` *| Enable [Celery support for Sentry](https://docs.sentry.io/platforms/python/celery/) |
+
+_* Enabling retry or celery support requires your application to list the relevant dependency (`pyramid_retry` or `celery`) as a dependency._ 
 
 As per the [Sentry docs](https://docs.sentry.io/error-reporting/configuration/?platform=python#dsn), the
 environment variable `SENTRY_DSN` will be automatically read if set, although this can

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 # https://setuptools.readthedocs.io/en/latest/setuptools.html#configuring-setup-using-setup-cfg-files
 [metadata]
 name = h_pyramid_sentry
-version = 1.0
+version = 1.1
 description = A Pyramid plugin for integrating Sentry error reporting
 long_description = file: README.md
 long_description_content_type = text/markdown
@@ -28,10 +28,11 @@ platforms=Operating System :: OS Independent
 install_requires =
     sentry-sdk
     pyramid
-    pyramid_retry
-    celery
+
 tests_require=
     pytest
     coverage
     h-matchers
+    pyramid_retry
+    celery
 

--- a/tests/unit/h_pyramid_sentry/__init___test.py
+++ b/tests/unit/h_pyramid_sentry/__init___test.py
@@ -36,10 +36,7 @@ class TestIncludeMe:
         includeme(pyramid_config)
 
         sentry_sdk.init.assert_called_once_with(
-            integrations=[
-                Any.instance_of(CeleryIntegration),
-                Any.instance_of(PyramidIntegration),
-            ],
+            integrations=[Any.instance_of(PyramidIntegration)],
             send_default_pii=True,
             before_send=Any.function(),
         )
@@ -76,6 +73,19 @@ class TestIncludeMe:
 
         get_before_send.assert_called_once_with([is_retryable_error])
         pyramid_config.scan.assert_called_with("h_pyramid_sentry.subscribers")
+
+    def test_it_reads_and_enables_celery_support(self, pyramid_config, sentry_sdk):
+        pyramid_config.registry.settings["h_pyramid_sentry.celery_support"] = True
+
+        includeme(pyramid_config)
+
+        sentry_sdk.init.assert_called_once_with(
+            # This is order sensitive, which we don't honestly care about.
+            # As and when list matchers become available we can replace this.
+            integrations=[Any(), Any.instance_of(CeleryIntegration)],
+            send_default_pii=True,
+            before_send=Any.function(),
+        )
 
     @pytest.fixture
     def pyramid_config(self):


### PR DESCRIPTION
Also updated the README to mention it exists and it's on you now to pull it in.

Also bumped the version number, as this isn't compatible with 1.0
as any app which had delegated their install of pyramid_retry or
celery to us would be dead now.