### PR TITLE
Fix isort (make format and make checkformatting)

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -23,7 +23,7 @@ jobs:
       run: |
         pip install black isort
         black --check src tests bin
-        isort --recursive --quiet --check-only .
+        isort --quiet --check-only .
 
     # Dependencies are checked by pylint,
     # so this is as late as we can leave this

--- a/tox.ini
+++ b/tox.ini
@@ -43,10 +43,10 @@ commands =
     lint: pylint --rcfile=tests/.pylintrc tests
 
     format: black {posargs:src tests bin}
-    format: isort --recursive --atomic .
+    format: isort --atomic .
 
     checkformatting: black --check {posargs:src tests bin}
-    checkformatting: isort --recursive --quiet --check-only .
+    checkformatting: isort --quiet --check-only .
 
     coverage: -coverage combine
     coverage: coverage report


### PR DESCRIPTION
isort 5.0 removed the `--recursive` option, it's now just always
recursive:

https://github.com/timothycrosley/isort/blob/develop/CHANGELOG.md#500-penny---july-4-2020