### PR TITLE
Add the Python classifiers for 3.7, 3.8 and 3.9

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -16,6 +16,9 @@ url = https://web.hypothes.is/
 classifiers =
     Development Status :: 2 - Pre-Alpha
     Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
     Framework :: Pyramid
     Topic :: System :: Monitoring
 


### PR DESCRIPTION
For: https://github.com/hypothesis/h-pyramid-sentry/issues/19

The classifiers were missing in the multi Python update.