### PR TITLE
Use the standard form of the template URL so `hdev` understands it

### DIFF
--- a/.cookiecutter.json
+++ b/.cookiecutter.json
@@ -11,5 +11,5 @@
             "src/h_pyramid_sentry/__init__.py"
         ]
     },
-    "_template": "git@github.com:hypothesis/h-cookiecutter-pypackage.git"
+    "_template": "gh:hypothesis/h-cookiecutter-pypackage"
 }


### PR DESCRIPTION
`hdev` uses the cookie cutter string to know this is one of our libraries. This was using a non-standard form of the URL. All the other libraries use this.