### PR TITLE
Fix a pytest deprecation warning

### DIFF
--- a/tests/unit/h_pyramid_sentry/__init___test.py
+++ b/tests/unit/h_pyramid_sentry/__init___test.py
@@ -2,7 +2,7 @@ from unittest import mock
 
 import pytest
 from h_matchers import Any
-from pyramid.testing import testConfig
+from pyramid import testing
 from sentry_sdk.integrations.celery import CeleryIntegration
 from sentry_sdk.integrations.pyramid import PyramidIntegration
 from sentry_sdk.integrations.sqlalchemy import SqlalchemyIntegration
@@ -99,7 +99,7 @@ class TestIncludeMe:
 
     @pytest.fixture
     def pyramid_config(self):
-        with testConfig() as config:
+        with testing.testConfig() as config:
             yield config
 
 


### PR DESCRIPTION
I think pytest was running the imported `testConfig` as a test!!

This should fix the tests, which are [currently broken on `main`](https://github.com/hypothesis/h-pyramid-sentry/actions/workflows/ci.yml?query=branch%3Amain) (spotted thanks to the scheduled nightly test run)