### PR TITLE
Fix CI

### DIFF
--- a/src/h_pyramid_sentry/__init__.py
+++ b/src/h_pyramid_sentry/__init__.py
@@ -1,6 +1,5 @@
 """Error tracking service API and setup."""
 
-
 import re
 
 import sentry_sdk

--- a/src/h_pyramid_sentry/event_filter.py
+++ b/src/h_pyramid_sentry/event_filter.py
@@ -1,4 +1,5 @@
 """An object which filters events."""
+
 import logging
 
 from h_pyramid_sentry.event import Event

--- a/src/h_pyramid_sentry/subscribers.py
+++ b/src/h_pyramid_sentry/subscribers.py
@@ -1,4 +1,5 @@
 """A pyramid subscriber to add extra info to retryable events."""
+
 import traceback
 
 import sentry_sdk

--- a/tests/unit/h_pyramid_sentry/__init___test.py
+++ b/tests/unit/h_pyramid_sentry/__init___test.py
@@ -81,7 +81,7 @@ class TestIncludeMe:
         includeme(pyramid_config)
 
         sentry_sdk.init.assert_called_once_with(
-            integrations=Any.list.containing([Any.instance_of(CeleryIntegration)]),
+            integrations=Any.list().containing([Any.instance_of(CeleryIntegration)]),
             send_default_pii=True,
             before_send=Any.function(),
         )
@@ -92,7 +92,9 @@ class TestIncludeMe:
         includeme(pyramid_config)
 
         sentry_sdk.init.assert_called_once_with(
-            integrations=Any.list.containing([Any.instance_of(SqlalchemyIntegration)]),
+            integrations=Any.list().containing(
+                [Any.instance_of(SqlalchemyIntegration)]
+            ),
             send_default_pii=True,
             before_send=Any.function(),
         )


### PR DESCRIPTION
1. Run `make format` to update the formatting to the latest Black behavior

2. Tweak the code to avoid a couple of false-positive warnings that pylint has started emitting.

   Pylint is confused by the crazy stuff that `h-matchers`'s "fluent entrypoint" decorator does in order to enable `Any.list.containing(...)` instead of having to write `Any.list().containing(...)`.
