### PR TITLE
Ignore a deprecation warning from `sentry_sdk`

### DIFF
--- a/.cookiecutter/includes/pytest/filterwarnings
+++ b/.cookiecutter/includes/pytest/filterwarnings
@@ -1,0 +1,1 @@
+"ignore:The `propagate_traces` parameter is deprecated\\. Please use `trace_propagation_targets` instead\\.:DeprecationWarning:",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ filterwarnings = [
     "ignore:^Deprecated call to .pkg_resources\\.declare_namespace\\('.*'\\).\\.:DeprecationWarning:pkg_resources",
     "ignore:^'cgi' is deprecated and slated for removal in Python 3\\.13$:DeprecationWarning:webob",
     "ignore:^datetime\\.datetime\\.utcnow\\(\\) is deprecated and scheduled for removal in a future version\\.:DeprecationWarning",
+    "ignore:The `propagate_traces` parameter is deprecated\\. Please use `trace_propagation_targets` instead\\.:DeprecationWarning:",
 ]
 
 [tool.pydocstyle]


### PR DESCRIPTION
As of its [2.21.0 release](https://github.com/getsentry/sentry-python/releases/tag/2.21.0) `sentry_sdk`'s Celery integration has begun emitting this deprecation warning:

    E       DeprecationWarning: The `propagate_traces` parameter is deprecated. Please use `trace_propagation_targets` instead.

    .tox/tests/lib/python3.12/site-packages/sentry_sdk/integrations/celery/__init__.py:73: DeprecationWarning

h-pyramid-sentry doesn't actually use the `propagate_traces` parameter. In fact all it's doing is inititalising `sentry_sdk`'s Celery integration with no arguments:

https://github.com/hypothesis/h-pyramid-sentry/blob/6de9124faa29ca99979bc08318af7c45e0487586/src/h_pyramid_sentry/__init__.py#L54-L56

`sentry_sdk` appears to [emit the warning unconditionally](https://github.com/getsentry/sentry-python/blob/25ddbcad9642cf38b7a9668e348f80fb9b1c892e/sentry_sdk/integrations/celery/__init__.py#L62-L77) whenever anyone uses the Celery integration:

    class CeleryIntegration(Integration):
        identifier = "celery"
        origin = f"auto.queue.{identifier}"

        def __init__(
            self,
            propagate_traces=True,
            monitor_beat_tasks=False,
            exclude_beat_tasks=None,
        ):
            # type: (bool, bool, Optional[List[str]]) -> None
            warnings.warn(
                "The `propagate_traces` parameter is deprecated. Please use `trace_propagation_targets` instead.",
                DeprecationWarning,
                stacklevel=2,
            )

The warning was added by this PR: https://github.com/getsentry/sentry-python/pull/3899.

Just ignore the warning, as there's no way for us to fix this.
